### PR TITLE
Fix ProfileOverlay border color to match background

### DIFF
--- a/frontend-dbdc-telegram-bot/src/components/ProfileOverlay.vue
+++ b/frontend-dbdc-telegram-bot/src/components/ProfileOverlay.vue
@@ -34,8 +34,8 @@
 
       
       <!-- Background -->
-      <div class="absolute inset-0 bg-gradient-to-r from-[#120B81] via-[#09074E] to-[#09074E] 
-                  border border-white border-opacity-8 backdrop-blur-[32px]"></div>
+      <div class="absolute inset-0 bg-gradient-to-r from-[#120B81] via-[#09074E] to-[#09074E]
+                  border border-[#09074E] backdrop-blur-[32px]"></div>
 
       <!-- Profile Header Section -->
       <div class="absolute top-3 left-3 right-3 z-[2]">

--- a/frontend-dbdc-telegram-bot/src/components/ProfileOverlay.vue
+++ b/frontend-dbdc-telegram-bot/src/components/ProfileOverlay.vue
@@ -5,7 +5,7 @@
                 left-[1.5rem] max-[360px]:left-[1.25rem] max-[375px]:left-[1.75rem] max-[414px]:left-[2rem]
                 sm:left-[5rem] md:left-[5.25rem] lg:left-[8.5rem] xl:left-[10.5rem]
 
-                bottom-[88px] max-[360px]:bottom-[78px] max-[375px]:bottom-[92px] max-[414px]:bottom-[95px]
+                bottom-[88px] max-[360px]:bottom-[78px] max-[375px]:bottom-[90px] max-[414px]:bottom-[95px]
                 sm:bottom-[130px] md:bottom-[140px] lg:bottom-[153px] xl:bottom-[175px]
 
                 z-[65] transition-all duration-300">

--- a/frontend-dbdc-telegram-bot/src/components/ProfileOverlay.vue
+++ b/frontend-dbdc-telegram-bot/src/components/ProfileOverlay.vue
@@ -5,7 +5,7 @@
                 left-[1.5rem] max-[360px]:left-[1.25rem] max-[375px]:left-[1.75rem] max-[414px]:left-[2rem]
                 sm:left-[5rem] md:left-[5.25rem] lg:left-[8.5rem] xl:left-[10.5rem]
 
-                bottom-[88px] max-[360px]:bottom-[78px] max-[375px]:bottom-[90px] max-[414px]:bottom-[95px]
+                bottom-[88px] max-[360px]:bottom-[78px] max-[375px]:bottom-[92px] max-[414px]:bottom-[95px]
                 sm:bottom-[130px] md:bottom-[140px] lg:bottom-[153px] xl:bottom-[175px]
 
                 z-[65] transition-all duration-300">

--- a/frontend-dbdc-telegram-bot/src/components/ProfileOverlay.vue
+++ b/frontend-dbdc-telegram-bot/src/components/ProfileOverlay.vue
@@ -2,13 +2,13 @@
   <div v-if="isVisible" class="fixed inset-0 z-50 font-montserrat bg-black bg-opacity-10 backdrop-blur-xl">
     <!-- Triangle Pointer -->
     <div class="absolute
-                left-[1.5rem] max-[360px]:left-[1.25rem] max-[375px]:left-[1.75rem] max-[414px]:left-[2rem]
-                sm:left-[5rem] md:left-[5.25rem] lg:left-[8.5rem] xl:left-[10.5rem]
+      left-[1.5rem] max-[360px]:left-[1.25rem] max-[375px]:left-[1.75rem] max-[414px]:left-[2rem]
+      sm:left-[5rem] md:left-[5.25rem] max-[1023px]:left-[6.25rem] lg:left-[8.5rem] max-[1279px]:left-[9.5rem] xl:left-[10.5rem]
 
-                bottom-[88px] max-[360px]:bottom-[78px] max-[375px]:bottom-[90px] max-[414px]:bottom-[95px]
-                sm:bottom-[130px] md:bottom-[140px] lg:bottom-[153px] xl:bottom-[175px]
+      bottom-[88px] max-[360px]:bottom-[78px] max-[375px]:bottom-[90px] max-[414px]:bottom-[95px]
+      sm:bottom-[130px] md:bottom-[140px] max-[1023px]:bottom-[148px] lg:bottom-[153px] max-[1279px]:bottom-[165px] xl:bottom-[175px]
 
-                z-[65] transition-all duration-300">
+      z-[65] transition-all duration-300">
       <div class="w-0 h-0 border-l-[12px] border-r-[12px] border-t-[15px] 
                   border-l-transparent border-r-transparent 
                   border-t-[rgba(18,11,129,0.95)] 
@@ -17,20 +17,21 @@
 
     <!-- Profile Dropdown Menu -->
     <div class="absolute
-                left-2 right-2 max-[375px]:left-[0.75rem] max-[375px]:right-[0.75rem]
-                sm:left-3 sm:right-3 md:left-4 md:right-4 lg:left-8 lg:right-8 xl:left-10 xl:right-10
+      left-2 right-2 max-[375px]:left-[0.75rem] max-[375px]:right-[0.75rem]
+      sm:left-3 sm:right-3 md:left-4 md:right-4 max-[1023px]:left-6 max-[1023px]:right-6 lg:left-8 lg:right-8 max-[1279px]:left-9 max-[1279px]:right-9 xl:left-10 xl:right-10
 
-                bottom-[98px] max-[360px]:bottom-[88px] max-[375px]:bottom-[100px] max-[414px]:bottom-[105px]
-                sm:bottom-[140px] md:bottom-[150px] lg:bottom-[163px] xl:bottom-[160px]
+      bottom-[98px] max-[360px]:bottom-[88px] max-[375px]:bottom-[100px] max-[414px]:bottom-[105px]
+      sm:bottom-[140px] md:bottom-[150px] max-[1023px]:bottom-[158px] lg:bottom-[163px] max-[1279px]:bottom-[170px] xl:bottom-[160px]
 
-                h-[500px] max-[360px]:h-[470px] max-[375px]:h-[490px] max-[414px]:h-[500px]
-                sm:h-[570px] md:h-[600px] lg:h-[700px] xl:h-[450px]
+      h-[500px] max-[360px]:h-[470px] max-[375px]:h-[490px] max-[414px]:h-[500px]
+      sm:h-[570px] md:h-[600px] max-[1023px]:h-[630px] lg:h-[700px] max-[1279px]:h-[600px] xl:h-[450px]
 
-                max-h-[calc(100vh-100px)] max-[360px]:max-h-[calc(100vh-90px)] max-[375px]:max-h-[calc(100vh-100px)] max-[414px]:max-h-[calc(100vh-110px)]
-                sm:max-h-[calc(100vh-150px)] md:max-h-[calc(100vh-315px)] lg:max-h-[calc(100vh-210px)] xl:max-h-[calc(100vh-200px)]
+      max-h-[calc(100vh-100px)] max-[360px]:max-h-[calc(100vh-90px)] max-[375px]:max-h-[calc(100vh-100px)] max-[414px]:max-h-[calc(100vh-110px)]
+      sm:max-h-[calc(100vh-150px)] md:max-h-[calc(100vh-315px)] max-[1023px]:max-h-[calc(100vh-280px)] lg:max-h-[calc(100vh-210px)] max-[1279px]:max-h-[calc(100vh-220px)] xl:max-h-[calc(100vh-200px)]
 
-                rounded-[20px] overflow-hidden z-[55] transition-all duration-300"
-        @click.stop>
+      rounded-[20px] overflow-hidden z-[55] transition-all duration-300"
+      @click.stop>
+
 
       
       <!-- Background -->

--- a/frontend-dbdc-telegram-bot/src/components/ProfileOverlay.vue
+++ b/frontend-dbdc-telegram-bot/src/components/ProfileOverlay.vue
@@ -2,8 +2,12 @@
   <div v-if="isVisible" class="fixed inset-0 z-50 font-montserrat bg-black bg-opacity-10 backdrop-blur-xl">
     <!-- Triangle Pointer -->
     <div class="absolute
-                left-[2.1rem] sm:left-[5rem] md:left-[5.25rem] lg:left-[8.5rem] xl:left-[10.5rem]
-                bottom-[98px] sm:bottom-[130px] md:bottom-[140px] lg:bottom-[153px] xl:bottom-[175px]
+                left-[1.5rem] max-[360px]:left-[1.25rem] max-[375px]:left-[1.75rem] max-[414px]:left-[2rem]
+                sm:left-[5rem] md:left-[5.25rem] lg:left-[8.5rem] xl:left-[10.5rem]
+
+                bottom-[88px] max-[360px]:bottom-[78px] max-[375px]:bottom-[90px] max-[414px]:bottom-[95px]
+                sm:bottom-[130px] md:bottom-[140px] lg:bottom-[153px] xl:bottom-[175px]
+
                 z-[65] transition-all duration-300">
       <div class="w-0 h-0 border-l-[12px] border-r-[12px] border-t-[15px] 
                   border-l-transparent border-r-transparent 
@@ -13,12 +17,21 @@
 
     <!-- Profile Dropdown Menu -->
     <div class="absolute
-                left-2 right-2 sm:left-3 sm:right-3 md:left-4 md:right-4 lg:left-8 lg:right-8 xl:left-10 xl:right-10
-                bottom-[108px] sm:bottom-[140px] md:bottom-[150px] lg:bottom-[163px] xl:bottom-[160px]
-                h-[550px] sm:h-[570px] md:h-[600px] lg:h-[700px] xl:h-[450px]
-                max-h-[calc(100vh-120px)] sm:max-h-[calc(100vh-150px)] md:max-h-[calc(100vh-315px)] lg:max-h-[calc(100vh-210px)] xl:max-h-[calc(100vh-200px)]
+                left-2 right-2 max-[375px]:left-[0.75rem] max-[375px]:right-[0.75rem]
+                sm:left-3 sm:right-3 md:left-4 md:right-4 lg:left-8 lg:right-8 xl:left-10 xl:right-10
+
+                bottom-[98px] max-[360px]:bottom-[88px] max-[375px]:bottom-[100px] max-[414px]:bottom-[105px]
+                sm:bottom-[140px] md:bottom-[150px] lg:bottom-[163px] xl:bottom-[160px]
+
+                h-[500px] max-[360px]:h-[470px] max-[375px]:h-[490px] max-[414px]:h-[500px]
+                sm:h-[570px] md:h-[600px] lg:h-[700px] xl:h-[450px]
+
+                max-h-[calc(100vh-100px)] max-[360px]:max-h-[calc(100vh-90px)] max-[375px]:max-h-[calc(100vh-100px)] max-[414px]:max-h-[calc(100vh-110px)]
+                sm:max-h-[calc(100vh-150px)] md:max-h-[calc(100vh-315px)] lg:max-h-[calc(100vh-210px)] xl:max-h-[calc(100vh-200px)]
+
                 rounded-[20px] overflow-hidden z-[55] transition-all duration-300"
         @click.stop>
+
       
       <!-- Background -->
       <div class="absolute inset-0 bg-gradient-to-r from-[#120B81] via-[#09074E] to-[#09074E] 


### PR DESCRIPTION
## Purpose
The user requested to fix the ProfileOverlay component where the border was white but needed to match the background fill color of the block instead.

## Code changes
- Changed border color from `border-white border-opacity-8` to `border-[#09074E]` to match the background gradient color
- Updated responsive positioning and sizing classes for better mobile and tablet support across various screen sizes
- Improved layout consistency by adding more granular breakpoint controls for left/right positioning, bottom positioning, height, and max-height properties

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 36`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c0acb86e08ba49ac8f6e618a98a9a86c/glow-oasis)

👀 [Preview Link](https://c0acb86e08ba49ac8f6e618a98a9a86c-glow-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c0acb86e08ba49ac8f6e618a98a9a86c</projectId>-->
<!--<branchName>glow-oasis</branchName>-->