### PR TITLE
Optimize safe area padding for iPhone bottom navigation

### DIFF
--- a/frontend-dbdc-telegram-bot/src/assets/tailwind.css
+++ b/frontend-dbdc-telegram-bot/src/assets/tailwind.css
@@ -399,6 +399,30 @@ textarea:focus-visible {
     padding-right: var(--safe-area-right);
 }
 
+/* Enhanced safe area support for iPhone and modern devices */
+.safe-area-inset-bottom {
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+.safe-area-enhanced-bottom {
+    padding-bottom: max(8px, env(safe-area-inset-bottom));
+}
+
+.safe-area-navigation-bottom {
+    padding-bottom: max(16px, calc(16px + env(safe-area-inset-bottom)));
+}
+
+/* iPhone specific optimizations */
+@supports (padding: max(0px)) {
+    .safe-bottom-enhanced {
+        padding-bottom: max(16px, calc(16px + env(safe-area-inset-bottom, 8px)));
+    }
+
+    .safe-margin-bottom {
+        margin-bottom: max(8px, env(safe-area-inset-bottom));
+    }
+}
+
 /* Performance optimizations */
 .gpu-acceleration {
     transform: translateZ(0);

--- a/frontend-dbdc-telegram-bot/src/components/BottomNavigation.vue
+++ b/frontend-dbdc-telegram-bot/src/components/BottomNavigation.vue
@@ -8,9 +8,9 @@
     />
 
     <!-- Bottom Navigation -->
-    <div class="fixed bottom-0 left-0 right-0 bg-white rounded-t-2xl sm:rounded-t-3xl shadow-[0_-4px_16px_rgba(0,0,0,0.08),0_-2px_6px_rgba(0,0,0,0.04)] border-t border-black/[0.06] z-[10001] pb-[env(safe-area-inset-bottom,0px)]">
+    <div class="fixed bottom-0 left-0 right-0 bg-white rounded-t-2xl sm:rounded-t-3xl shadow-[0_-4px_16px_rgba(0,0,0,0.08),0_-2px_6px_rgba(0,0,0,0.04)] border-t border-black/[0.06] z-[10001] pb-[max(8px,env(safe-area-inset-bottom))]">
       <!-- Navigation Content -->
-      <div class="flex items-center justify-center p-3 sm:p-4 pb-[calc(12px+env(safe-area-inset-bottom,0px))] sm:pb-[calc(16px+env(safe-area-inset-bottom,0px))] min-h-[64px] sm:min-h-[72px]">
+      <div class="flex items-center justify-center p-3 sm:p-4 pb-[max(12px,calc(12px+env(safe-area-inset-bottom)))] sm:pb-[max(16px,calc(16px+env(safe-area-inset-bottom)))] min-h-[64px] sm:min-h-[72px]">
         <!-- Navigation Items Container -->
         <div class="flex items-center justify-between w-full gap-2 sm:gap-4 px-2 sm:px-4">
 

--- a/frontend-dbdc-telegram-bot/src/components/BottomNavigation.vue
+++ b/frontend-dbdc-telegram-bot/src/components/BottomNavigation.vue
@@ -8,7 +8,7 @@
     />
 
     <!-- Bottom Navigation -->
-    <div class="fixed bottom-0 left-0 right-0 bg-white rounded-t-2xl sm:rounded-t-3xl shadow-[0_-4px_16px_rgba(0,0,0,0.08),0_-2px_6px_rgba(0,0,0,0.04)] border-t border-black/[0.06] z-[10001] pb-[max(8px,env(safe-area-inset-bottom))]">
+    <div class="fixed bottom-0 left-0 right-0 bg-white rounded-t-2xl sm:rounded-t-3xl shadow-[0_-4px_16px_rgba(0,0,0,0.08),0_-2px_6px_rgba(0,0,0,0.04)] border-t border-black/[0.06] z-[10001] pb-[max(4px,env(safe-area-inset-bottom))]">
       <!-- Navigation Content -->
       <div class="flex items-center justify-center p-3 sm:p-4 pb-[max(12px,calc(12px+env(safe-area-inset-bottom)))] sm:pb-[max(16px,calc(16px+env(safe-area-inset-bottom)))] min-h-[64px] sm:min-h-[72px]">
         <!-- Navigation Items Container -->

--- a/frontend-dbdc-telegram-bot/src/views/StartView.vue
+++ b/frontend-dbdc-telegram-bot/src/views/StartView.vue
@@ -49,7 +49,7 @@
     </div>
 
     <!-- Bottom Section -->
-    <div class="bg-white p-4 border-t border-black/5 safe-bottom">
+    <div class="bg-white p-4 border-t border-black/5 pb-[calc(1rem+env(safe-area-inset-bottom,8px))]">
       <button @click="handleStart" class="w-full h-12 sm:h-13 md:h-14 lg:h-15 bg-gradient-to-r from-dbd-primary to-[#473FFF] border-0 rounded-full text-white font-bold text-sm sm:text-base md:text-lg lg:text-xl font-montserrat cursor-pointer transition-all duration-200 ease-out shadow-lg hover:shadow-xl active:scale-98 outline-none touch-manipulation">
         Start
       </button>
@@ -116,8 +116,24 @@ onMounted(() => {
   -webkit-backface-visibility: hidden;
 }
 
-/* Safe area handling for iOS and other devices with home indicator */
+/* Enhanced safe area handling for iOS and other devices with home indicator */
 .safe-bottom {
+  padding-bottom: calc(16px + env(safe-area-inset-bottom, 8px));
+}
+
+/* Additional safe area utility classes */
+.safe-area-bottom {
   padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+.safe-area-bottom-enhanced {
+  padding-bottom: calc(16px + env(safe-area-inset-bottom, 8px));
+}
+
+/* Specific iPhone safe area optimizations */
+@supports (padding: max(0px)) {
+  .safe-bottom {
+    padding-bottom: max(16px, calc(16px + env(safe-area-inset-bottom)));
+  }
 }
 </style>

--- a/frontend-dbdc-telegram-bot/src/views/StartView.vue
+++ b/frontend-dbdc-telegram-bot/src/views/StartView.vue
@@ -49,7 +49,7 @@
     </div>
 
     <!-- Bottom Section -->
-    <div class="bg-white p-4 border-t border-black/5 pb-[calc(1rem+env(safe-area-inset-bottom,8px))]">
+    <div class="bg-white p-4 border-t border-black/5 pb-[max(1rem,calc(4px+env(safe-area-inset-bottom)))]">
       <button @click="handleStart" class="w-full h-12 sm:h-13 md:h-14 lg:h-15 bg-gradient-to-r from-dbd-primary to-[#473FFF] border-0 rounded-full text-white font-bold text-sm sm:text-base md:text-lg lg:text-xl font-montserrat cursor-pointer transition-all duration-200 ease-out shadow-lg hover:shadow-xl active:scale-98 outline-none touch-manipulation">
         Start
       </button>
@@ -118,7 +118,7 @@ onMounted(() => {
 
 /* Enhanced safe area handling for iOS and other devices with home indicator */
 .safe-bottom {
-  padding-bottom: calc(16px + env(safe-area-inset-bottom, 8px));
+  padding-bottom: max(16px, calc(4px + env(safe-area-inset-bottom)));
 }
 
 /* Additional safe area utility classes */
@@ -127,13 +127,13 @@ onMounted(() => {
 }
 
 .safe-area-bottom-enhanced {
-  padding-bottom: calc(16px + env(safe-area-inset-bottom, 8px));
+  padding-bottom: max(12px, calc(4px + env(safe-area-inset-bottom)));
 }
 
 /* Specific iPhone safe area optimizations */
 @supports (padding: max(0px)) {
   .safe-bottom {
-    padding-bottom: max(16px, calc(16px + env(safe-area-inset-bottom)));
+    padding-bottom: max(16px, calc(4px + env(safe-area-inset-bottom)));
   }
 }
 </style>

--- a/frontend-dbdc-telegram-bot/src/views/StartView.vue
+++ b/frontend-dbdc-telegram-bot/src/views/StartView.vue
@@ -49,11 +49,7 @@
     </div>
 
     <!-- Bottom Section -->
-<<<<<<< HEAD
-    <div class="bg-white p-4 border-t border-black/5 pb-[max(1rem,calc(4px+env(safe-area-inset-bottom)))]">
-=======
-    <div class="bg-white p-3 sm:p-4 md:p-5 lg:p-6 border-t border-black/5 pb-[calc(0.75rem+env(safe-area-inset-bottom,0px))] sm:pb-[calc(1rem+env(safe-area-inset-bottom,0px))] md:pb-[calc(1.25rem+env(safe-area-inset-bottom,0px))] lg:pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))]">
->>>>>>> origin/main
+    <div class="bg-white p-3 sm:p-4 md:p-5 lg:p-6 border-t border-black/5 pb-[max(0.75rem,calc(4px+env(safe-area-inset-bottom)))] sm:pb-[max(1rem,calc(4px+env(safe-area-inset-bottom)))] md:pb-[max(1.25rem,calc(4px+env(safe-area-inset-bottom)))] lg:pb-[max(1.5rem,calc(4px+env(safe-area-inset-bottom)))]">
       <button @click="handleStart" class="w-full h-12 sm:h-13 md:h-14 lg:h-15 bg-gradient-to-r from-dbd-primary to-[#473FFF] border-0 rounded-full text-white font-bold text-sm sm:text-base md:text-lg lg:text-xl font-montserrat cursor-pointer transition-all duration-200 ease-out shadow-lg hover:shadow-xl active:scale-98 outline-none touch-manipulation">
         Start
       </button>
@@ -119,7 +115,6 @@ onMounted(() => {
   backface-visibility: hidden;
   -webkit-backface-visibility: hidden;
 }
-<<<<<<< HEAD
 
 /* Enhanced safe area handling for iOS and other devices with home indicator */
 .safe-bottom {
@@ -141,6 +136,4 @@ onMounted(() => {
     padding-bottom: max(16px, calc(4px + env(safe-area-inset-bottom)));
   }
 }
-=======
->>>>>>> origin/main
 </style>


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses excessive bottom padding in the StartView and BottomNavigation components for iPhone and other devices with safe areas. The users requested minimal safe area spacing and expressed concerns about overly large margins, particularly for iPhone "swipe" areas and home indicators.

## Code Changes

### CSS Enhancements (`tailwind.css`)
- Added new safe area utility classes with enhanced iPhone support
- Implemented `safe-area-inset-bottom`, `safe-area-enhanced-bottom`, and `safe-area-navigation-bottom` classes
- Added iPhone-specific optimizations using `@supports` queries with `max()` functions

### Component Updates
- **BottomNavigation.vue**: Updated padding to use `max(4px, env(safe-area-inset-bottom))` for more minimal spacing
- **StartView.vue**: Replaced generic `safe-bottom` class with optimized `max(1rem, calc(4px + env(safe-area-inset-bottom)))` padding

### Safe Area Strategy
- Uses `max()` function to ensure minimum padding while respecting device safe areas
- Provides fallback values for devices without safe area insets
- Reduces excessive spacing while maintaining proper iPhone home indicator clearance

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 66`

🔗 [Edit in Builder.io](https://builder.io/app/projects/cfb58d43ef1642c188095bb7101c21aa/aura-studio)

👀 [Preview Link](https://cfb58d43ef1642c188095bb7101c21aa-aura-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>cfb58d43ef1642c188095bb7101c21aa</projectId>-->
<!--<branchName>aura-studio</branchName>-->