### PR TITLE
feat: align profile overlay with bottom navigation

### DIFF
--- a/frontend-dbdc-telegram-bot/src/components/BottomNavigation.vue
+++ b/frontend-dbdc-telegram-bot/src/components/BottomNavigation.vue
@@ -227,7 +227,7 @@
 </template>
 
 <script setup>
-import { ref, watch, nextTick, onMounted, onUnmounted } from 'vue'
+import { ref, watch, nextTick, onMounted, onUnmounted, reactive } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useCart } from '../composables/useCart.js'
 import ProfileOverlay from './ProfileOverlay.vue'
@@ -242,7 +242,10 @@ const { cartItemsCount } = useCart()
 // Profile menu state
 const isProfileMenuOpen = ref(false)
 const profileButton = ref(null)
-const profileButtonPosition = ref({ left: 0, width: 0 })
+const profileButtonPosition = reactive({
+  left: 0,
+  width: 0
+})
 
 // Computed active tab based on current route
 const activeTab = ref('wallet')
@@ -280,48 +283,37 @@ const navigateTo = (tab) => {
 const updateProfileButtonPosition = () => {
   if (profileButton.value) {
     const rect = profileButton.value.getBoundingClientRect()
-    profileButtonPosition.value = {
-      left: rect.left,
-      width: rect.width
-    }
+    profileButtonPosition.left = rect.left
+    profileButtonPosition.width = rect.width
   }
 }
 
-const toggleProfile = async () => {
-  console.log('Profile toggle clicked, current state:', isProfileMenuOpen.value)
-
-  if (!isProfileMenuOpen.value) {
-    // Calculate position before opening
-    await nextTick()
-    updateProfileButtonPosition()
-  }
-
+const toggleProfile = () => {
   isProfileMenuOpen.value = !isProfileMenuOpen.value
-  console.log('Profile toggle new state:', isProfileMenuOpen.value)
 
-  // Telegram WebApp haptic feedback
   if (window.Telegram && window.Telegram.WebApp && window.Telegram.WebApp.HapticFeedback) {
     window.Telegram.WebApp.HapticFeedback.impactOccurred('medium')
   }
 }
 
 const closeProfileMenu = () => {
-  console.log('Profile menu close requested')
   isProfileMenuOpen.value = false
-  console.log('Profile menu closed, state:', isProfileMenuOpen.value)
 }
 
-// Window resize handler
-const handleResize = () => {
-  if (isProfileMenuOpen.value) {
+watch(isProfileMenuOpen, async (val) => {
+  if (val) {
+    await nextTick()
     updateProfileButtonPosition()
   }
+})
+
+const handleResize = () => {
+  updateProfileButtonPosition()
 }
 
-// Lifecycle hooks
 onMounted(() => {
-  window.addEventListener('resize', handleResize)
   updateProfileButtonPosition()
+  window.addEventListener('resize', handleResize)
 })
 
 onUnmounted(() => {

--- a/frontend-dbdc-telegram-bot/src/components/ProfileOverlay.vue
+++ b/frontend-dbdc-telegram-bot/src/components/ProfileOverlay.vue
@@ -1,14 +1,8 @@
 <template>
-  <div v-if="isVisible" class="fixed inset-0 z-[9999] font-montserrat bg-black/10 backdrop-blur-xl min-h-screen">
-    <!-- Dropdown Wrapper -->
+  <div v-if="isVisible" class="fixed inset-0 z-[9999] font-montserrat bg-black/10 backdrop-blur-xl">
     <div
-      class="absolute inset-x-4 sm:inset-x-6 md:inset-x-8 lg:inset-x-12 xl:inset-x-20 2xl:inset-x-24
-            bottom-[calc(64px+env(safe-area-inset-bottom,0px)+20px)]
-            sm:bottom-[calc(72px+env(safe-area-inset-bottom,0px)+40px)]
-            md:bottom-[calc(88px+env(safe-area-inset-bottom,0px)+32px)]
-            lg:bottom-[calc(96px+env(safe-area-inset-bottom,0px)+24px)]
-            xl:bottom-[calc(104px+env(safe-area-inset-bottom,0px)+28px)]
-            flex flex-col items-start z-[9999]">
+      class="fixed inset-x-4 sm:inset-x-6 md:inset-x-8 lg:inset-x-12 xl:inset-x-20 2xl:inset-x-24 flex flex-col items-start z-[9999]"
+      :style="overlayStyle">
 
       <!-- Dropdown Menu -->
       <div class="w-full
@@ -475,26 +469,38 @@
           </div>
         </div>
       </div>
-      <!-- Triangle Pointer -->
-      <div class="ml-6 sm:ml-10 md:ml-14 lg:ml-20 xl:ml-14 2xl:ml-30 mt-[-1px] mb-2">
-        <div class="w-0 h-0 border-l-[12px] border-r-[12px] border-t-[15px]
-                    border-l-transparent border-r-transparent border-t-[#09074E] drop-shadow-md"></div>
-      </div>
     </div>
+    <div
+      class="fixed w-0 h-0 border-l-[12px] border-r-[12px] border-t-[15px] border-l-transparent border-r-transparent border-t-[#09074E] drop-shadow-md"
+      :style="triangleStyle"></div>
   </div>
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import CountryFlag from './CountryFlag.vue'
 
 // Props
-defineProps({
+const props = defineProps({
   isVisible: {
     type: Boolean,
     default: false
+  },
+  triggerPosition: {
+    type: Object,
+    default: () => ({ left: 0, width: 0 })
   }
 })
+
+const overlayStyle = {
+  bottom: 'calc(88px + env(safe-area-inset-bottom, 0px) + 15px)'
+}
+
+const triangleStyle = computed(() => ({
+  left: `${props.triggerPosition.left + props.triggerPosition.width / 2 - 12}px`,
+  bottom: 'calc(88px + env(safe-area-inset-bottom, 0px))',
+  marginBottom: '-1px'
+}))
 
 // Emits
 const emit = defineEmits(['close'])


### PR DESCRIPTION
## Summary
- align ProfileOverlay pointer to Profile button by passing live trigger position
- keep overlay anchored above BottomNavigation with responsive safe-area offset

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688d4bd8050c8333a27ff0643c713140