### PR TITLE
Fix BottomNavigation keyboard overlay in Telegram WebApp

### DIFF
--- a/frontend-dbdc-telegram-bot/src/components/BottomNavigation.vue
+++ b/frontend-dbdc-telegram-bot/src/components/BottomNavigation.vue
@@ -424,6 +424,29 @@ const getRankIcon = (rank) => {
   }
 }
 
+/* Keyboard-aware positioning for Telegram WebApp */
+.bottom-nav-with-keyboard {
+  bottom: 0;
+  /* When keyboard is open, push navigation down by keyboard height */
+  transform: translateY(var(--keyboard-height, 0px));
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Ensure navigation stays behind keyboard overlay */
+@supports (env(keyboard-inset-height)) {
+  .bottom-nav-with-keyboard {
+    bottom: calc(0px + env(keyboard-inset-height, 0px));
+    transform: none;
+  }
+}
+
+/* Fallback for browsers that don't support keyboard-inset-height */
+@media screen and (max-height: 500px) {
+  .bottom-nav-with-keyboard {
+    transform: translateY(calc(var(--keyboard-height, 0px) + 20px));
+  }
+}
+
 /* Reduced motion support */
 @media (prefers-reduced-motion: reduce) {
   .transition-all,
@@ -433,6 +456,10 @@ const getRankIcon = (rank) => {
 
   .active\:scale-95:active {
     transform: none !important;
+  }
+
+  .bottom-nav-with-keyboard {
+    transition: none !important;
   }
 }
 </style>

--- a/frontend-dbdc-telegram-bot/src/components/BottomNavigation.vue
+++ b/frontend-dbdc-telegram-bot/src/components/BottomNavigation.vue
@@ -9,7 +9,7 @@
     />
 
     <!-- Bottom Navigation -->
-    <div ref="bottomNav" class="fixed bottom-0 left-0 right-0 bg-white rounded-t-2xl shadow-[0_-4px_16px_rgba(0,0,0,0.08),0_-2px_6px_rgba(0,0,0,0.04)] border-t border-black/[0.06] z-[10001]">
+    <div ref="bottomNav" class="fixed left-0 right-0 bg-white rounded-t-2xl shadow-[0_-4px_16px_rgba(0,0,0,0.08),0_-2px_6px_rgba(0,0,0,0.04)] border-t border-black/[0.06] z-[10001] bottom-nav-with-keyboard">
       <!-- Navigation Content -->
       <div class="flex items-center justify-center px-3 pt-3 pb-[max(env(safe-area-inset-bottom),1rem)]">
         <!-- Navigation Items Container -->


### PR DESCRIPTION
## Purpose

The user wanted to prevent the BottomNavigation component from being pushed up when the keyboard opens in Telegram WebApp. Instead of the navigation moving above the keyboard, they wanted the keyboard to overlay on top of other elements while keeping modal windows accessible.

## Code changes

- Added `bottom-nav-with-keyboard` CSS class to the BottomNavigation component
- Implemented keyboard-aware positioning using CSS transforms and `--keyboard-height` variable
- Added support for `env(keyboard-inset-height)` for browsers that support it
- Included fallback styles for smaller screens (max-height: 500px)
- Added smooth transition animations with cubic-bezier easing
- Ensured compatibility with reduced motion preferences

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 81`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fd1067f73f82429c8a65466221733758/cosmos-forge)

👀 [Preview Link](https://fd1067f73f82429c8a65466221733758-cosmos-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fd1067f73f82429c8a65466221733758</projectId>-->
<!--<branchName>cosmos-forge</branchName>-->