### PR TITLE
Fix keyboard overlap with bottom navigation in Telegram WebApp

### DIFF
--- a/frontend-dbdc-telegram-bot/src/views/AccountCheckView.vue
+++ b/frontend-dbdc-telegram-bot/src/views/AccountCheckView.vue
@@ -89,7 +89,7 @@
     <div
       class="fixed bottom-0 left-0 right-0 bg-white/75 backdrop-blur-sm p-4"
       :style="{
-        paddingBottom: isTelegramWebApp ? 'calc(1rem + var(--tg-safe-area-inset-bottom, 0px))' : '1rem'
+        paddingBottom: isTelegramWebApp ? 'calc(1rem + var(--tg-safe-area-bottom, 0px))' : '1rem'
       }"
     >
       <button

--- a/frontend-dbdc-telegram-bot/src/views/AccountCheckView.vue
+++ b/frontend-dbdc-telegram-bot/src/views/AccountCheckView.vue
@@ -87,10 +87,7 @@
 
     <!-- Bottom Telegram Button -->
     <div
-      class="fixed bottom-0 left-0 right-0 bg-white/75 backdrop-blur-sm p-4"
-      :style="{
-        paddingBottom: isTelegramWebApp ? 'calc(1rem + var(--tg-safe-area-bottom, 0px))' : '1rem'
-      }"
+      class="fixed bottom-0 left-0 right-0 bg-white/75 backdrop-blur-sm p-4 pb-[max(var(--tg-content-safe-area-inset-bottom),1rem)]"
     >
       <button
         @click="handleTelegramContinue"

--- a/frontend-dbdc-telegram-bot/src/views/AccountCheckView.vue
+++ b/frontend-dbdc-telegram-bot/src/views/AccountCheckView.vue
@@ -87,7 +87,7 @@
 
     <!-- Bottom Telegram Button -->
     <div
-      class="fixed bottom-0 left-0 right-0 bg-white/75 backdrop-blur-sm p-4 pb-[max(var(--tg-content-safe-area-inset-bottom),1rem)]"
+      class="fixed bottom-0 left-0 right-0 bg-white/75 backdrop-blur-sm p-4 pb-[max(var(--tg-content-safe-area-inset-bottom),1rem)] z-10"
     >
       <button
         @click="handleTelegramContinue"


### PR DESCRIPTION
## Purpose

The user wanted to fix keyboard behavior in the Telegram WebApp where:
- The "Continue with Telegram" button in AccountCheck was positioned too high
- The BottomNavigation component was not properly adjusting when the virtual keyboard appeared
- The keyboard should properly overlay or push up UI elements instead of hiding them

## Code changes

**BottomNavigation.vue:**
- Added keyboard detection logic for Telegram WebApp using viewport height changes
- Implemented dynamic positioning that moves the bottom navigation above the keyboard when visible
- Added transition animations for smooth keyboard appearance/disappearance
- Enhanced viewport change listeners for both Telegram WebApp and regular browsers
- Added fallback keyboard detection for non-Telegram environments

**AccountCheckView.vue:**
- Simplified bottom button styling by removing custom padding logic
- Applied consistent safe area inset using `pb-[max(var(--tg-content-safe-area-inset-bottom),1rem)]`
- Added `z-10` to ensure proper layering with keyboard

The changes ensure the bottom navigation properly responds to keyboard events and maintains appropriate spacing in the Telegram WebApp environment.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 102`

🔗 [Edit in Builder.io](https://builder.io/app/projects/feb4bc0b5ea742398181b65195fca127/glow-haven)

👀 [Preview Link](https://feb4bc0b5ea742398181b65195fca127-glow-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>feb4bc0b5ea742398181b65195fca127</projectId>-->
<!--<branchName>glow-haven</branchName>-->