### PR TITLE
Fix referral link display and copy functionality

### DIFF
--- a/frontend-dbdc-telegram-bot/src/views/HoldersView.vue
+++ b/frontend-dbdc-telegram-bot/src/views/HoldersView.vue
@@ -469,10 +469,14 @@ const copyLink = async () => {
     console.warn('Could not get invite data, using cached link:', error)
   }
 
+  // Add inviting text with the link
+  const shareText = 'Join me in DBD Capital Forevers! 🚀 Start earning digital assets with this amazing bot.'
+  const fullTextToCopy = `${shareText}\n\n${linkToCopy}`
+
   // Try modern clipboard API first
   if (navigator.clipboard) {
     try {
-      await navigator.clipboard.writeText(linkToCopy)
+      await navigator.clipboard.writeText(fullTextToCopy)
       copySuccess = true
     } catch (clipboardErr) {
       console.log('Clipboard API failed, trying fallback method')
@@ -483,7 +487,7 @@ const copyLink = async () => {
   if (!copySuccess) {
     try {
       const textArea = document.createElement('textarea')
-      textArea.value = linkToCopy
+      textArea.value = fullTextToCopy
       textArea.style.position = 'fixed'
       textArea.style.left = '-999999px'
       textArea.style.top = '-999999px'


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses several issues with the referral link functionality in HoldersView:
- Display full referral links instead of truncated versions with "..." 
- Fix copy functionality on mobile devices that wasn't working properly
- Add inviting text to shared/copied links (similar to Telegram WebApp sharing patterns)

## Code changes

**Link Display Improvements:**
- Removed link truncation logic from `shortenedReferralLink` computed property
- Updated CSS classes to use smaller text sizes (`text-xs` instead of `text-lg`) with `break-all` for proper wrapping
- Added padding and max-width constraints to prevent overflow while showing full URLs

**Copy Functionality Fixes:**
- Enhanced `copyWebLink()` with mobile-optimized fallback methods
- Added proper text selection and timing for mobile keyboards
- Improved error handling and user feedback with haptic feedback
- Now copies inviting text along with the link: "Join me in DBD Capital Forevers! 🚀 Start earning digital assets with this amazing bot."

**Sharing Text Updates:**
- Updated share text across `shareQRCode()` and `copyLink()` functions
- Added more descriptive and engaging invitation message for better user acquisition

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 116`

🔗 [Edit in Builder.io](https://builder.io/app/projects/27630893c7ae4d6ca9522c54f2b08e6b/mystic-lab)

👀 [Preview Link](https://27630893c7ae4d6ca9522c54f2b08e6b-mystic-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>27630893c7ae4d6ca9522c54f2b08e6b</projectId>-->
<!--<branchName>mystic-lab</branchName>-->