### PR TITLE
Fix referral link copy functionality in HoldersView

### DIFF
--- a/frontend-dbdc-telegram-bot/src/views/HoldersView.vue
+++ b/frontend-dbdc-telegram-bot/src/views/HoldersView.vue
@@ -542,8 +542,6 @@ const copyLink = async () => {
 }
 
 const copyWebLink = async () => {
-  showSuccessMessage('🔧 copyWebLink called')
-
   // Add haptic feedback when copy button is pressed
   if (window.triggerHaptic) {
     window.triggerHaptic('impact', 'light')
@@ -553,38 +551,29 @@ const copyWebLink = async () => {
 
   // Get the actual full link to copy - backend already provides WebApp format
   let linkToCopy = telegramWebAppLink.value
-  showSuccessMessage(`📋 Initial link: ${linkToCopy?.substring(0, 50)}...`)
 
   try {
     const inviteData = await referralService.getInviteData()
     linkToCopy = inviteData.invite_link
-    showSuccessMessage(`🔄 Updated link from API: ${linkToCopy?.substring(0, 50)}...`)
   } catch (error) {
-    showSuccessMessage(`❌ API Error: ${error.message}`)
+    console.warn('Could not get fresh invite data, using cached link:', error)
   }
 
   // Add "Join me on.." text as is typical in Telegram apps
   const fullMessageToCopy = `Join me on DBD Capital Forevers! 🚀\n\n${linkToCopy}`
-  showSuccessMessage(`📝 Full message length: ${fullMessageToCopy.length} chars`)
 
   // Try modern clipboard API first
-  showSuccessMessage(`📋 Clipboard available: ${!!navigator.clipboard}`)
-  if (navigator.clipboard) {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
     try {
-      showSuccessMessage('🔄 Attempting clipboard.writeText...')
       await navigator.clipboard.writeText(fullMessageToCopy)
       copySuccess = true
-      showSuccessMessage('✅ Clipboard API success!')
     } catch (clipboardErr) {
-      showSuccessMessage(`❌ Clipboard failed: ${clipboardErr.message}`)
+      console.log('Clipboard API failed, trying fallback method:', clipboardErr)
     }
-  } else {
-    showSuccessMessage('⚠️ Clipboard not available, using fallback')
   }
 
   // If clipboard API failed or is not available, use fallback
   if (!copySuccess) {
-    showSuccessMessage('🔄 Attempting fallback copy...')
     try {
       const textArea = document.createElement('textarea')
       textArea.value = fullMessageToCopy
@@ -592,36 +581,34 @@ const copyWebLink = async () => {
       textArea.style.left = '-999999px'
       textArea.style.top = '-999999px'
       textArea.style.opacity = '0'
+      textArea.style.pointerEvents = 'none'
       document.body.appendChild(textArea)
       textArea.focus()
       textArea.select()
+      textArea.setSelectionRange(0, 99999) // For mobile devices
 
-      showSuccessMessage('📝 TextArea created, attempting execCommand...')
       const successful = document.execCommand('copy')
       document.body.removeChild(textArea)
 
       if (successful) {
         copySuccess = true
-        showSuccessMessage('✅ Fallback copy successful!')
-      } else {
-        showSuccessMessage('❌ execCommand returned false')
       }
     } catch (fallbackErr) {
-      showSuccessMessage(`❌ Fallback error: ${fallbackErr.message}`)
+      console.error('Fallback copy failed:', fallbackErr)
     }
   }
 
   if (copySuccess) {
-    showSuccessMessage('✅ Copy completed successfully!')
+    showSuccessMessage('✅ Link copied to clipboard!')
     // Add success haptic feedback
     if (window.triggerHaptic) {
       window.triggerHaptic('notification', 'success')
     }
   } else {
-    showSuccessMessage('❌ All copy methods FAILED!')
+    showSuccessMessage('❌ Unable to copy link. Please try again.')
     // Still provide haptic feedback for user interaction
     if (window.triggerHaptic) {
-      window.triggerHaptic('impact', 'light')
+      window.triggerHaptic('impact', 'medium')
     }
   }
 


### PR DESCRIPTION
## Purpose

The user reported that the referral link copy functionality in the WebReferralLink block of HoldersView was not working properly. Instead of successfully copying the link, they were getting an error message "❌ All copy methods FAILED!" and the referral link was not being copied to the clipboard.

## Code changes

- **Removed excessive debug messages**: Eliminated multiple `showSuccessMessage()` calls that were cluttering the copy process and potentially interfering with the functionality
- **Improved clipboard API detection**: Added proper check for `navigator.clipboard.writeText` availability before attempting to use it
- **Enhanced fallback copy method**: 
  - Added `pointerEvents: 'none'` style to prevent interference
  - Added `setSelectionRange(0, 99999)` for better mobile device compatibility
- **Replaced debug messages with console logging**: Changed error logging from user-visible messages to console warnings/errors
- **Updated user feedback messages**: 
  - Success message now shows "✅ Link copied to clipboard!" instead of debug info
  - Failure message changed to "❌ Unable to copy link. Please try again." for better UX
- **Improved haptic feedback**: Changed failure haptic from 'light' to 'medium' impact for better user feedback

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 125`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7e756984baf445aa8e23f981fcfc6b72/nova-works)

👀 [Preview Link](https://7e756984baf445aa8e23f981fcfc6b72-nova-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7e756984baf445aa8e23f981fcfc6b72</projectId>-->
<!--<branchName>nova-works</branchName>-->