### PR TITLE
Center copied text in GeneratedPasswordView

### DIFF
--- a/frontend-dbdc-telegram-bot/src/views/GeneratedPasswordView.vue
+++ b/frontend-dbdc-telegram-bot/src/views/GeneratedPasswordView.vue
@@ -19,7 +19,7 @@
           </span>
         </div>
         <!-- Copied State -->
-        <div v-if="copied" class="flex-1 px-4 sm:px-6 py-3.5 overflow-hidden flex items-center justify-start">
+        <div v-if="copied" class="flex-1 px-4 sm:px-6 py-3.5 overflow-hidden flex items-center justify-center">
           <div class="link-copied-content flex items-center gap-2">
             <span class="link-copied-text text-white font-bold">Copied</span>
             <div class="link-copied-icon">


### PR DESCRIPTION
## Purpose

The user wanted to center the "Copied" text and icon that appears when the copy action is triggered in the GeneratedPassword component, while keeping the password display itself left-aligned.

## Code changes

- Changed the flex justification from `justify-start` to `justify-center` in the copied state div
- This centers the "Copied" text and icon horizontally within the container when the copy action is triggered
- The password display remains unaffected and stays left-aligned

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 130`

🔗 [Edit in Builder.io](https://builder.io/app/projects/cae40a09b5f24660bb0adf7318b1dfb7/spark-nest)

👀 [Preview Link](https://cae40a09b5f24660bb0adf7318b1dfb7-spark-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>cae40a09b5f24660bb0adf7318b1dfb7</projectId>-->
<!--<branchName>spark-nest</branchName>-->