### PR TITLE
Fix validation parameter in CryptoInitiateRequest schema

### DIFF
--- a/backend/schemas/crypto_purchase.py
+++ b/backend/schemas/crypto_purchase.py
@@ -11,7 +11,7 @@ class CryptoForeversItem(BaseModel):
 
 
 class CryptoInitiateRequest(BaseModel):
-    forevers_details: conlist(CryptoForeversItem, min_items=1) = Field(..., alias='foreversDetails')
+    forevers_details: conlist(CryptoForeversItem, min_length=1) = Field(..., alias='foreversDetails')
     ton_address: str = Field(..., alias='tonAddress')
     slippage_percent: Optional[float] = Field(2.0, alias='slippagePercent')
 


### PR DESCRIPTION
## Purpose
Based on the conversation history, the user was experiencing issues with their Telegram app backend service, as evidenced by error logs from the Docker container. The changes appear to be addressing validation issues in the crypto purchase schema to resolve runtime errors.

## Code changes
- Updated `CryptoInitiateRequest` schema in `backend/schemas/crypto_purchase.py`
- Changed `min_items=1` to `min_length=1` in the `forevers_details` field validation
- This fixes the validation parameter to use the correct constraint for list length validation in Pydantic models

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 152`

🔗 [Edit in Builder.io](https://builder.io/app/projects/94dfd48eec5b42f0b81b4d92004e9252/orbit-zone)

👀 [Preview Link](https://94dfd48eec5b42f0b81b4d92004e9252-orbit-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>94dfd48eec5b42f0b81b4d92004e9252</projectId>-->
<!--<branchName>orbit-zone</branchName>-->