### PR TITLE
Fix TON wallet connection and add privacy/terms URLs

### DIFF
--- a/frontend-dbdc-telegram-bot/public/tonconnect-manifest.json
+++ b/frontend-dbdc-telegram-bot/public/tonconnect-manifest.json
@@ -1,5 +1,5 @@
 {
-  "url": "http://localhost:5173",
-  "name": "DBDC Forevers Dev",
+  "url": "https://6000e60c7d0f40c4b042c1aa1fe48ce2-cf30b71a-7615-4303-bee4-57f172.fly.dev",
+  "name": "DBDC Forevers",
   "iconUrl": "/dbd-logo.svg"
 }

--- a/frontend-dbdc-telegram-bot/public/tonconnect-manifest.json
+++ b/frontend-dbdc-telegram-bot/public/tonconnect-manifest.json
@@ -1,5 +1,7 @@
 {
   "url": "https://6000e60c7d0f40c4b042c1aa1fe48ce2-cf30b71a-7615-4303-bee4-57f172.fly.dev",
   "name": "DBDC Forevers",
-  "iconUrl": "/dbd-logo.svg"
+  "iconUrl": "/dbd-logo.svg",
+  "privacyPolicyUrl": "https://dbdcusa.com/uploads/docs/04_ENG_DBD_Capital_Privacy_Policy.docx.pdf",
+  "termsOfUseUrl": "https://dbd.capital/uploads/docs/DBDC_Terms_and_Conditions_of_Website_Use_ENG.pdf"
 }

--- a/frontend-dbdc-telegram-bot/public/tonconnect-manifest.json
+++ b/frontend-dbdc-telegram-bot/public/tonconnect-manifest.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://6000e60c7d0f40c4b042c1aa1fe48ce2-cf30b71a-7615-4303-bee4-57f172.fly.dev",
+  "url": "https://dbdc-mini.dubadu.com",
   "name": "DBDC Forevers",
   "iconUrl": "/dbd-logo.svg",
   "privacyPolicyUrl": "https://dbdcusa.com/uploads/docs/04_ENG_DBD_Capital_Privacy_Policy.docx.pdf",

--- a/frontend-dbdc-telegram-bot/src/composables/useTonConnect.js
+++ b/frontend-dbdc-telegram-bot/src/composables/useTonConnect.js
@@ -59,5 +59,7 @@ export function useTonConnect() {
     return { boc }
   }
 
-  return { connector: ui, isConnected, ensureConnected, getAddress, sendTransaction }
+  const getChain = () => ui?.account?.chain || null
+
+  return { connector: ui, isConnected, ensureConnected, getAddress, getChain, sendTransaction }
 }

--- a/frontend-dbdc-telegram-bot/src/composables/useTonConnect.js
+++ b/frontend-dbdc-telegram-bot/src/composables/useTonConnect.js
@@ -47,8 +47,12 @@ export function useTonConnect() {
   const getAddress = () => addressRef.value || ui?.account?.address || null
 
   const sendTransaction = async (to, amountNano, validUntil) => {
+    const account = ui.account
     const tx = {
-      validUntil,
+      // use provided validUntil or default to +10 minutes
+      validUntil: validUntil || Math.floor(Date.now() / 1000) + 600,
+      // ensure we send on the same network as the connected wallet
+      network: account?.chain,
       messages: [{ address: to, amount: amountNano.toString() }]
     }
     const boc = await ui.sendTransaction(tx)

--- a/frontend-dbdc-telegram-bot/src/services/cryptoPaymentService.js
+++ b/frontend-dbdc-telegram-bot/src/services/cryptoPaymentService.js
@@ -2,7 +2,9 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'https://dbdc-mini.dub
 
 export const CryptoPaymentService = {
   async initiate(order) {
-    const res = await fetch(`${API_BASE_URL}/forevers/crypto/initiate`, {
+    const url = new URL(`${API_BASE_URL}/forevers/crypto/initiate`)
+    if (order?.chain) url.searchParams.set('chain', order.chain)
+    const res = await fetch(url.toString(), {
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },

--- a/frontend-dbdc-telegram-bot/src/views/SelectTypePayment.vue
+++ b/frontend-dbdc-telegram-bot/src/views/SelectTypePayment.vue
@@ -230,7 +230,7 @@ const handleBack = () => {
   router.go(-1)
 }
 
-const { ensureConnected, getAddress, sendTransaction, isConnected } = useTonConnect()
+const { ensureConnected, getAddress, getChain, sendTransaction, isConnected } = useTonConnect()
 
 const primaryActionLabel = computed(() => {
   if (selectedPayment.value === 'crypto' && !isConnected.value) return 'Connect Wallet'

--- a/frontend-dbdc-telegram-bot/src/views/SelectTypePayment.vue
+++ b/frontend-dbdc-telegram-bot/src/views/SelectTypePayment.vue
@@ -272,8 +272,9 @@ const handlePurchase = async () => {
       const fromAddr = getAddress()
       if (!fromAddr) throw new Error('Wallet is not connected')
 
-      // initiate order with address so backend can bind it
-      const initRes = await CryptoPaymentService.initiate({ foreversDetails: items, tonAddress: fromAddr })
+      // initiate order with address and network chain so backend selects the right network
+      const chain = getChain()
+      const initRes = await CryptoPaymentService.initiate({ foreversDetails: items, tonAddress: fromAddr, chain })
 
       await sendTransaction(initRes.to_address, initRes.amount_nano, initRes.valid_until)
 


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses critical issues with the TON wallet connection functionality:
- Users reported that the "Connect Wallet" button was not working properly and immediately redirecting to transactions
- Transaction errors were occurring, particularly on testnet
- Missing privacy policy and terms of use URLs in the TON Connect manifest were needed for proper wallet integration

## Code changes

**TON Connect Manifest Updates:**
- Updated production URL from localhost to `https://dbdc-mini.dubadu.com`
- Removed "Dev" from app name for production deployment
- Added required `privacyPolicyUrl` and `termsOfUseUrl` fields for compliance

**Wallet Connection Improvements:**
- Enhanced transaction handling with proper network chain detection
- Added fallback `validUntil` timestamp (10 minutes default) for transactions
- Implemented network-aware transaction sending to match connected wallet's chain
- Added `getChain()` method to retrieve wallet's network information

**Payment Service Integration:**
- Modified crypto payment initiation to include chain parameter
- Ensures backend selects correct network based on connected wallet's chain
- Improved order binding with both address and network context

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 155`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6000e60c7d0f40c4b042c1aa1fe48ce2/quantum-haven)

👀 [Preview Link](https://6000e60c7d0f40c4b042c1aa1fe48ce2-quantum-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6000e60c7d0f40c4b042c1aa1fe48ce2</projectId>-->
<!--<branchName>quantum-haven</branchName>-->