### PR TITLE
Remove user address from crypto transaction verification

### DIFF
--- a/frontend-dbdc-telegram-bot/src/views/SelectTypePayment.vue
+++ b/frontend-dbdc-telegram-bot/src/views/SelectTypePayment.vue
@@ -384,7 +384,6 @@ async function handleCryptoPurchaseFlow() {
 
     const verify = await CryptoService.verifyCryptoTransaction({
       boc: result?.boc,
-      address: userAddress?.value || null,
       reference: initResp.reference,
       total_usd: Number(numericTotal.value.toFixed(2)),
       items


### PR DESCRIPTION
## Purpose
Fix TON Connect integration issue where verification only worked for specific payer accounts. The user reported that TON Connect was only functioning when a specific payer wallet was indicated in the code, but the payer wallet should not be hardcoded. Only the recipient wallet should be configured via environment variables.

## Code changes
- Removed `address: userAddress?.value || null` parameter from `CryptoService.verifyCryptoTransaction()` call in SelectTypePayment.vue
- This eliminates the hardcoded payer address dependency and allows TON Connect to work with any payer wallet

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 162`

🔗 [Edit in Builder.io](https://builder.io/app/projects/04c50d8cf6724f8784a45c11a76394e8/vibe-den)

👀 [Preview Link](https://04c50d8cf6724f8784a45c11a76394e8-vibe-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>04c50d8cf6724f8784a45c11a76394e8</projectId>-->
<!--<branchName>vibe-den</branchName>-->